### PR TITLE
_pages/teaching: Descriptive link to theses

### DIFF
--- a/_pages/teaching.html
+++ b/_pages/teaching.html
@@ -29,7 +29,7 @@ author_profile: true
 <ul>
     <li>Nguyen Luong (doctoral student) since November 2021</li>
     <li>Arsi Ikäheimonen (doctoral student) since October 2021 </li>
-    <li><a href="/teaching/theses/">Link</a> to some of the BSc and MSc theses that I have supervised.</li>
+    <li><a href="/teaching/theses/">List of some of the BSc and MSc theses I have supervised</li>.
 </ul>
 
 


### PR DESCRIPTION
I once read that descriptive links like this are better for users and also for search engines